### PR TITLE
chore: Fix broken LICENSE link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Helper Community License 1.0
 
-https://github.com/anti-work/helper/LICENSE.md
+https://github.com/anti-work/helper/blob/main/LICENSE.md
 
 ## Acceptance
 


### PR DESCRIPTION
The current link [https://github.com/anti-work/helper/LICENSE.md](https://github.com/anti-work/helper/LICENSE.md) in the LICENSE document appears to be broken. This PR replaces it with a functioning canonical link.