### PR TITLE
fix: enable file drag and drop in Tauri

### DIFF
--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
         .setup(|app| {
             let mut win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
                 .title("Helper")
+                .disable_drag_drop_handler()
                 .inner_size(1200.0, 800.0);
 
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
[ref](https://anti--work.slack.com/archives/C055QQCQFM1/p1740585122481209)

Tauri's native drag and drop breaks dragging files into the reply editor.