### PR TITLE
docs: fix SSL certificate generation script name in README and development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ _For other operating systems, see the [mkcert installation guide](https://github
 
 ```sh
 # Generate SSL certificates
-bin/generate_ssl_certs
+bin/generate_ssl_certificates
 ```
 
 3. Start the application:

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ Then, create a local Certificate Authority and generate SSL certificates for the
 
 ```sh
 # Generate SSL certificates
-bin/generate_ssl_certs
+bin/generate_ssl_certificates
 ```
 
 Run the application and access it at [helperai.dev](https://helperai.dev):


### PR DESCRIPTION
Fixed incorrect script name from `bin/generate_ssl_certs` to `bin/generate_ssl_certificates` in:
- README.md
- docs/development.md

This ensures the documentation matches the actual script name in the `bin` directory.